### PR TITLE
Write multipart boundary at end after writing all parts in the continuation invoker

### DIFF
--- a/actor/executor.go
+++ b/actor/executor.go
@@ -68,7 +68,6 @@ func (exec *graphExecutor) HandleInvokeStage(msg *model.InvokeStageRequest) *mod
 	buf := new(bytes.Buffer)
 
 	partWriter := multipart.NewWriter(buf)
-	defer partWriter.Close()
 
 	if msg.Closure != nil {
 		err := protocol.WritePartFromDatum(exec.blobStore, &model.Datum{Val: &model.Datum_Blob{Blob: msg.Closure}}, partWriter)
@@ -86,6 +85,8 @@ func (exec *graphExecutor) HandleInvokeStage(msg *model.InvokeStageRequest) *mod
 
 		}
 	}
+
+	partWriter.Close()
 
 	req, _ := http.NewRequest("POST", exec.faasAddr+"/"+msg.FunctionId, buf)
 	req.Header.Set("Content-type", fmt.Sprintf("multipart/form-data; boundary=\"%s\"", partWriter.Boundary()))


### PR DESCRIPTION
The multipart writer wasn't being closed until exiting`HandleInvokeStage`, so the multipart boundary wasn't written after all the parts had been written. As well as being inconsistent with our API documentation, this causes some multipart parsers to ignore the final part (the epilogue in RFC1341: https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html).