### PR TITLE
Remove protoc zip after install, otherwise tree is dirty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
            # Move protoc3/include to /usr/local/include/
            sudo mv protoc3/include/* /usr/local/include/
            rm -rf protoc3
+           rm -f protoc-3.3.0-linux-x86_64.zip
            go get -u github.com/golang/protobuf/protoc-gen-go
       # update Docker
       - run: |


### PR DESCRIPTION
Remove protoc zip after install, otherwise tree is dirty and release.sh fails